### PR TITLE
modified the treeviewInitialize function

### DIFF
--- a/sooScreenClient/mainwindow.cpp
+++ b/sooScreenClient/mainwindow.cpp
@@ -72,6 +72,8 @@ void MainWindow::treeviewInitialize()
     GuiHelpers::addSettingsCat(this,ui->twSettings,m_transportBackends,m_work.trans()->getParameters(),QString("Transport layer"),section::transport,static_cast<int>(m_selectedTransportBackend));
     m_transistion = false;
     ui->twSettings->expandAll();
+    ui->twSettings->setColumnWidth(0, this->width()/2.5f);
+    ui->twSettings->setColumnWidth(1, this->width()/12);
 }
 
 void MainWindow::writeData()

--- a/sooScreenServer/mainwindow.cpp
+++ b/sooScreenServer/mainwindow.cpp
@@ -103,6 +103,8 @@ void MainWindow::treeviewInitialize()
     GuiHelpers::addSettingsCat(this,ui->twSettings,m_transportBackends,m_work.trans()->getParameters(),QString("Transport layer"),section::transport,static_cast<int>(m_selectedTransportBackend));
     m_transistion = false;
     ui->twSettings->expandAll();
+    ui->twSettings->setColumnWidth(0, this->width()/2.5f);
+    ui->twSettings->setColumnWidth(1, this->width()/12);
 }
 
 void MainWindow::writeData()


### PR DESCRIPTION
Modified the treeviewInitialize function in client and server to set the column width of the first and second column on init, so the full text is shown. Fix issue #12 